### PR TITLE
#10 Let users provide device name on User.generateDeviceKeys() API call

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ SDK for using IronCore Labs from your NodeJS server side applications. Read [our
 
 ## Supported Platforms
 
-|           | Node 8 | Node 10 |
-| --------- | ------ | ------- |
-| Linux x64 |    ✓   |    ✓    |
-| OSX x64   |    ✓   |    ✓    |
+|           | Node 8 | Node 9  | Node 10 | Node 11 |
+| --------- | ------ | ------- | ------- | ------- |
+| Linux x64 |    ✓   |    ✓    |    ✓    |    ✓    |
+| OSX x64   |    ✓   |    ✓    |    ✓    |    ✓    |
 
 ## Installation
 
@@ -18,7 +18,7 @@ SDK for using IronCore Labs from your NodeJS server side applications. Read [our
 
 This SDK relies on our [recrypt-node-binding](https://github.com/IronCoreLabs/recrypt-node-binding) Node addon library. This library is distributed as a binary which is specific to both an architecture (OSX/Linux) and Node version (8/10). When you NPM install this SDK it will automatically determine the proper binary to pull down into your `node_modules` directory based on your architecture and Node version.
 
-This means that you'll need to make sure that the machine that runs `npm install` to install this libraary is the architecture/Node version where the code will run. This library will not work if you run `npm install` on an OSX machine and move the node_modules directory over to a Linux machine, for example.
+This means that you'll need to make sure that the machine that runs `npm install` to install this library is the architecture/Node version where the code will run. This library will not work if you run `npm install` on an OSX machine and move the node_modules directory over to a Linux machine, for example.
 
 If the machine you run `npm install` on is not one of the supported architectures you will get an install failure. If there's an architecture or Node version that you'd like supported that isn't yet available, [open a new issue](https://github.com/IronCoreLabs/ironnode/issues/new) and we'll look into adding support for it.
 

--- a/integration/userOperation.ts
+++ b/integration/userOperation.ts
@@ -76,7 +76,7 @@ function createUser() {
  */
 function generateLocalDeviceKeys() {
     return inquirer
-        .prompt<{userID: string; password: string}>([
+        .prompt<{userID: string; password: string; deviceName: string}>([
             {
                 type: "input",
                 name: "userID",
@@ -87,9 +87,14 @@ function generateLocalDeviceKeys() {
                 name: "password",
                 message: "Input users private key escrow password: ",
             },
+            {
+                type: "input",
+                name: "deviceName",
+                message: "Provide a name for these device keys: ",
+            },
         ])
-        .then(({userID, password}) => {
-            return User.generateDeviceKeys(generateJWT(userID), password);
+        .then(({userID, password, deviceName}) => {
+            return User.generateDeviceKeys(generateJWT(userID), password, {deviceName});
         })
         .then((deviceDetails) => {
             fs.writeFileSync(path.join(__dirname, "./.device.json"), JSON.stringify(deviceDetails));

--- a/ironnode.d.ts
+++ b/ironnode.d.ts
@@ -10,6 +10,9 @@ export interface DocumentAccessList {
     groups?: Array<{id: string}>;
 }
 
+export interface DeviceCreateOptions {
+    deviceName: string;
+}
 export interface DocumentCreateOptions {
     documentID?: string;
     documentName?: string;
@@ -155,5 +158,5 @@ export interface DeviceDetails {
 export namespace User {
     export function verify(jwt: string): Promise<ApiUserResponse | undefined>;
     export function create(jwt: string, password: string): Promise<ApiUserResponse>;
-    export function generateDeviceKeys(jwt: string, password: string): Promise<DeviceDetails>;
+    export function generateDeviceKeys(jwt: string, password: string, options?: DeviceCreateOptions): Promise<DeviceDetails>;
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "lint": "tslint -p \"tsconfig.json\" -e \"**/tests/**\" \"src/**/*.ts\""
     },
     "dependencies": {
-        "@ironcorelabs/recrypt-node-binding": "0.4.1",
+        "@ironcorelabs/recrypt-node-binding": "0.4.2",
         "futurejs": "2.0.0",
         "node-fetch": "2.2.0"
     },

--- a/src/api/tests/UserApi.test.ts
+++ b/src/api/tests/UserApi.test.ts
@@ -126,7 +126,9 @@ describe("UserApi", () => {
                 })
             );
 
-            UserApi.callUserDeviceAdd("jwt", TestUtils.getEmptyPublicKey(), TestUtils.getTransformKey(), Buffer.from([99, 103, 113, 93]), 133353523).engage(
+            UserApi.callUserDeviceAdd("jwt", TestUtils.getEmptyPublicKey(), TestUtils.getTransformKey(), Buffer.from([99, 103, 113, 93]), 133353523, {
+                deviceName: "blah",
+            }).engage(
                 (e) => fail(e),
                 (result) => {
                     expect(result).toEqual({
@@ -136,6 +138,40 @@ describe("UserApi", () => {
                     const request = (ApiRequest.fetchJSON as jest.Mock).mock.calls[0][2];
                     expect(request.headers.Authorization).toEqual("jwt jwt");
                     expect(request.method).toEqual("POST");
+                    expect(JSON.parse(request.body)).toEqual({
+                        timestamp: 133353523,
+                        userPublicKey: {x: "", y: ""},
+                        device: {
+                            transformKey: {
+                                ephemeralPublicKey: {x: "", y: ""},
+                                toPublicKey: {x: "", y: ""},
+                                encryptedTempKey: "",
+                                hashedTempKey: "",
+                                publicSigningKey: "",
+                                signature: "",
+                            },
+                            name: "blah",
+                        },
+                        signature: "Y2dxXQ==",
+                    });
+                    done();
+                }
+            );
+        });
+
+        test("shouldnt pass device name if not provided", (done) => {
+            (ApiRequest.fetchJSON as jest.Mock).mockReturnValue(
+                Future.of({
+                    devicePublicKey: {x: "", y: ""},
+                })
+            );
+
+            UserApi.callUserDeviceAdd("jwt", TestUtils.getEmptyPublicKey(), TestUtils.getTransformKey(), Buffer.from([99, 103, 113, 93]), 133353523, {
+                deviceName: "",
+            }).engage(
+                (e) => fail(e),
+                () => {
+                    const request = (ApiRequest.fetchJSON as jest.Mock).mock.calls[0][2];
                     expect(JSON.parse(request.body)).toEqual({
                         timestamp: 133353523,
                         userPublicKey: {x: "", y: ""},

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import * as Initialization from "./sdk/Initialization";
 import {Base64String} from "./commonTypes";
+import {DeviceCreateOptions} from "../ironnode";
 
 /**
  * Initialize the Node SDK by providing account information necessary to run operations from a server side context. Returns a Promise which
@@ -35,12 +36,14 @@ export const User = {
      * Generate a new pair of device keys for the user specified in the provided signed JWT. Takes the users password in order to decrypt their master
      * keys and generates a new device key pair as well as a transform key between their master key pair and their device key pair. Returns both the
      * device key pair and a signing key pair as base64 encoded strings as well as the users ID and the segment ID for the user. All of these fields can
-     * then be stored somewhere secure and passed in to run the `initialize` function in order for the current user to interact with the SDK.
-     * @param {string} jwt      Signed JWT for the user to sync
-     * @param {string} password Password to use to escrow the users private key
+     * then be stored somewhere secure and passed in to run the `initialize` function in order for the current user to interact with the SDK. Also allows
+     * the call to provide a readable "name" for this device.
+     * @param {string}              jwt      Signed JWT for the user to sync
+     * @param {string}              password Password to use to escrow the users private key
+     * @param {DeviceCreateOptions} options  Device create options.
      */
-    generateDeviceKeys(jwt: string, password: string) {
-        return Initialization.generateDevice(jwt, password).toPromise();
+    generateDeviceKeys(jwt: string, password: string, deviceOptions: DeviceCreateOptions = {deviceName: ""}) {
+        return Initialization.generateDevice(jwt, password, deviceOptions).toPromise();
     },
 };
 

--- a/src/operations/tests/DocumentOperations.test.ts
+++ b/src/operations/tests/DocumentOperations.test.ts
@@ -272,7 +272,7 @@ describe("DocumentOperations", () => {
         });
     });
 
-    fdescribe("encryptBytes", () => {
+    describe("encryptBytes", () => {
         test("encrypts document to current user and returns expected document package", () => {
             const encryptedSymKey = TestUtils.getEncryptedSymmetricKey();
 

--- a/src/operations/tests/DocumentOperations.test.ts
+++ b/src/operations/tests/DocumentOperations.test.ts
@@ -272,11 +272,13 @@ describe("DocumentOperations", () => {
         });
     });
 
-    describe("encryptBytes", () => {
+    fdescribe("encryptBytes", () => {
         test("encrypts document to current user and returns expected document package", () => {
             const encryptedSymKey = TestUtils.getEncryptedSymmetricKey();
 
-            const encryptSpy = jest.spyOn(DocumentCrypto, "encryptBytes");
+            const encryptBytes = jest.spyOn(DocumentCrypto, "encryptBytes");
+            encryptBytes.mockReturnValue(Future.of(Buffer.alloc(33)));
+            const encryptSpy = jest.spyOn(DocumentCrypto, "encryptPlaintextToUsersAndGroups");
             encryptSpy.mockReturnValue(
                 Future.of({
                     userAccessKeys: [{id: "10", key: encryptedSymKey}],
@@ -292,17 +294,21 @@ describe("DocumentOperations", () => {
                 ({document, documentID, documentName}) => {
                     expect(documentID).toEqual("bar");
                     expect(documentName).toBeUndefined();
-                    expect(document).toEqual(Buffer.alloc(55));
+                    expect(document).toEqual(Buffer.alloc(33));
                     const currentUserRecord = {
                         id: "10",
                         masterPublicKey: TestUtils.accountPublicBytesBase64,
                     };
-                    expect(DocumentCrypto.encryptBytes).toHaveBeenCalledWith(
-                        generateDocumentHeaderBytes("my doc ID", TestUtils.testSegmentID),
-                        Buffer.from([]),
+                    expect(DocumentCrypto.encryptPlaintextToUsersAndGroups).toHaveBeenCalledWith(
+                        jasmine.any(Buffer),
                         [currentUserRecord],
                         [],
                         ApiState.signingKeys().privateKey
+                    );
+                    expect(DocumentCrypto.encryptBytes).toHaveBeenCalledWith(
+                        generateDocumentHeaderBytes("my doc ID", TestUtils.testSegmentID),
+                        Buffer.from([]),
+                        jasmine.any(Buffer)
                     );
                     expect(DocumentApi.callDocumentCreateApi).toHaveBeenCalledWith("my doc ID", [{id: "10", key: encryptedSymKey}], [], "");
                 }
@@ -313,12 +319,14 @@ describe("DocumentOperations", () => {
             const docName = "my doc";
             const encryptedSymKey = TestUtils.getEncryptedSymmetricKey();
 
-            const encryptSpy = jest.spyOn(DocumentCrypto, "encryptBytes");
+            const encryptBytes = jest.spyOn(DocumentCrypto, "encryptBytes");
+            encryptBytes.mockReturnValue(Future.of(Buffer.alloc(33)));
+            const encryptSpy = jest.spyOn(DocumentCrypto, "encryptPlaintextToUsersAndGroups");
             encryptSpy.mockReturnValue(
                 Future.of({
                     userAccessKeys: [{id: "10", key: encryptedSymKey}],
                     groupAccessKeys: [],
-                    encryptedDocument: Buffer.alloc(55),
+                    encryptedDocument: Buffer.alloc(33),
                 })
             );
             const apiSpy = jest.spyOn(DocumentApi, "callDocumentCreateApi");
@@ -329,7 +337,7 @@ describe("DocumentOperations", () => {
                 ({document, documentID, documentName}) => {
                     expect(documentID).toEqual("bar");
                     expect(documentName).toEqual(docName);
-                    expect(document).toEqual(Buffer.alloc(55));
+                    expect(document).toEqual(Buffer.alloc(33));
                 }
             );
         });
@@ -352,7 +360,10 @@ describe("DocumentOperations", () => {
                     result: [{id: "group-20", groupMasterPublicKey: TestUtils.getEmptyPublicKeyString()}],
                 })
             );
-            const encryptSpy = jest.spyOn(DocumentCrypto, "encryptBytes");
+
+            const encryptBytes = jest.spyOn(DocumentCrypto, "encryptBytes");
+            encryptBytes.mockReturnValue(Future.of(Buffer.alloc(33)));
+            const encryptSpy = jest.spyOn(DocumentCrypto, "encryptPlaintextToUsersAndGroups");
             encryptSpy.mockReturnValue(
                 Future.of({
                     userAccessKeys: [{id: "10", key: encryptedSymKey}],
@@ -368,7 +379,7 @@ describe("DocumentOperations", () => {
                 ({documentID, documentName, document}) => {
                     expect(documentID).toEqual("bar");
                     expect(documentName).toBeUndefined();
-                    expect(document).toEqual(Buffer.alloc(55));
+                    expect(document).toEqual(Buffer.alloc(33));
 
                     const userKeyList = [
                         {id: "user-55", masterPublicKey: TestUtils.getEmptyPublicKeyString()},
@@ -380,6 +391,10 @@ describe("DocumentOperations", () => {
                     expect(DocumentCrypto.encryptBytes).toHaveBeenCalledWith(
                         generateDocumentHeaderBytes("doc key", TestUtils.testSegmentID),
                         Buffer.from([88, 73, 92]),
+                        jasmine.any(Buffer)
+                    );
+                    expect(DocumentCrypto.encryptPlaintextToUsersAndGroups).toHaveBeenCalledWith(
+                        jasmine.any(Buffer),
                         userKeyList,
                         groupKeyList,
                         ApiState.signingKeys().privateKey
@@ -419,7 +434,9 @@ describe("DocumentOperations", () => {
         test("encrypts document to current user and returns expected document package", () => {
             const encryptedSymKey = TestUtils.getEncryptedSymmetricKey();
 
-            const encryptSpy = jest.spyOn(DocumentCrypto, "encryptStream");
+            const encryptStreamSpy = jest.spyOn(DocumentCrypto, "encryptStream");
+            encryptStreamSpy.mockReturnValue(Future.of(undefined));
+            const encryptSpy = jest.spyOn(DocumentCrypto, "encryptPlaintextToUsersAndGroups");
             encryptSpy.mockReturnValue(
                 Future.of({
                     userAccessKeys: [{id: "10", key: encryptedSymKey}],
@@ -438,13 +455,17 @@ describe("DocumentOperations", () => {
                         id: "10",
                         masterPublicKey: TestUtils.accountPublicBytesBase64,
                     };
-                    expect(DocumentCrypto.encryptStream).toHaveBeenCalledWith(
-                        generateDocumentHeaderBytes("my doc ID", TestUtils.testSegmentID),
-                        "inputStream",
-                        "outputStream",
+                    expect(DocumentCrypto.encryptPlaintextToUsersAndGroups).toHaveBeenCalledWith(
+                        jasmine.any(Buffer),
                         [currentUserRecord],
                         [],
                         ApiState.signingKeys().privateKey
+                    );
+                    expect(DocumentCrypto.encryptStream).toHaveBeenCalledWith(
+                        generateDocumentHeaderBytes("my doc ID", TestUtils.testSegmentID),
+                        jasmine.any(Buffer),
+                        "inputStream",
+                        "outputStream"
                     );
                     expect(DocumentApi.callDocumentCreateApi).toHaveBeenCalledWith("my doc ID", [{id: "10", key: encryptedSymKey}], [], "");
                 }
@@ -455,7 +476,9 @@ describe("DocumentOperations", () => {
             const docName = "my doc";
             const encryptedSymKey = TestUtils.getEncryptedSymmetricKey();
 
-            const encryptSpy = jest.spyOn(DocumentCrypto, "encryptStream");
+            const encryptStreamSpy = jest.spyOn(DocumentCrypto, "encryptStream");
+            encryptStreamSpy.mockReturnValue(Future.of(undefined));
+            const encryptSpy = jest.spyOn(DocumentCrypto, "encryptPlaintextToUsersAndGroups");
             encryptSpy.mockReturnValue(
                 Future.of({
                     userAccessKeys: [{id: "10", key: encryptedSymKey}],
@@ -492,7 +515,9 @@ describe("DocumentOperations", () => {
                     result: [{id: "group-20", groupMasterPublicKey: TestUtils.getEmptyPublicKeyString()}],
                 })
             );
-            const encryptSpy = jest.spyOn(DocumentCrypto, "encryptStream");
+            const encryptStreamSpy = jest.spyOn(DocumentCrypto, "encryptStream");
+            encryptStreamSpy.mockReturnValue(Future.of(undefined));
+            const encryptSpy = jest.spyOn(DocumentCrypto, "encryptPlaintextToUsersAndGroups");
             encryptSpy.mockReturnValue(
                 Future.of({
                     userAccessKeys: [{id: "10", key: encryptedSymKey}],
@@ -515,13 +540,17 @@ describe("DocumentOperations", () => {
                     ];
                     const groupKeyList = [{id: "group-20", masterPublicKey: TestUtils.getEmptyPublicKeyString()}];
 
-                    expect(DocumentCrypto.encryptStream).toHaveBeenCalledWith(
-                        generateDocumentHeaderBytes("doc key", TestUtils.testSegmentID),
-                        "inputStream",
-                        "outputStream",
+                    expect(DocumentCrypto.encryptPlaintextToUsersAndGroups).toHaveBeenCalledWith(
+                        jasmine.any(Buffer),
                         userKeyList,
                         groupKeyList,
                         ApiState.signingKeys().privateKey
+                    );
+                    expect(DocumentCrypto.encryptStream).toHaveBeenCalledWith(
+                        generateDocumentHeaderBytes("doc key", TestUtils.testSegmentID),
+                        jasmine.any(Buffer),
+                        "inputStream",
+                        "outputStream"
                     );
                     expect(DocumentApi.callDocumentCreateApi).toHaveBeenCalledWith("doc key", [{id: "10", key: encryptedSymKey}], [], "");
                     done();
@@ -550,6 +579,47 @@ describe("DocumentOperations", () => {
                     done();
                 },
                 () => fail("Should not call create when any user or group could not be found")
+            );
+        });
+
+        test("doesnt run encrypt stream if document create call fails", (done) => {
+            const docSpy = jest.spyOn(DocumentApi, "callDocumentCreateApi");
+            docSpy.mockReturnValue(Future.reject(new Error("forced request failure")));
+
+            const encryptedSymKey = TestUtils.getEncryptedSymmetricKey();
+
+            const userSpy = jest.spyOn(UserApi, "callUserKeyListApi");
+            userSpy.mockReturnValue(
+                Future.of({
+                    result: [
+                        {id: "user-55", userMasterPublicKey: TestUtils.getEmptyPublicKeyString()},
+                        {id: "user-33", userMasterPublicKey: TestUtils.getEmptyPublicKeyString()},
+                    ],
+                })
+            );
+            const groupSpy = jest.spyOn(GroupApi, "callGroupKeyListApi");
+            groupSpy.mockReturnValue(
+                Future.of({
+                    result: [{id: "group-20", groupMasterPublicKey: TestUtils.getEmptyPublicKeyString()}],
+                })
+            );
+            const encryptStreamSpy = jest.spyOn(DocumentCrypto, "encryptStream");
+            encryptStreamSpy.mockReturnValue(Future.of(undefined));
+            const encryptSpy = jest.spyOn(DocumentCrypto, "encryptPlaintextToUsersAndGroups");
+            encryptSpy.mockReturnValue(
+                Future.of({
+                    userAccessKeys: [{id: "10", key: encryptedSymKey}],
+                    groupAccessKeys: [],
+                })
+            );
+
+            DocumentOperations.encryptStream("doc key", "inputStream" as any, "outputStream" as any, "", ["user-55", "user-33"], ["user-33"]).engage(
+                (e: any) => {
+                    expect(e.message).toEqual("forced request failure");
+                    expect(DocumentCrypto.encryptStream).not.toHaveBeenCalled();
+                    done();
+                },
+                () => fail("Should not succeed when API request fails.")
             );
         });
     });

--- a/src/sdk/tests/Initialization.test.ts
+++ b/src/sdk/tests/Initialization.test.ts
@@ -172,7 +172,7 @@ describe("Initialization", () => {
         test("rejects if user doesnt exist", () => {
             jest.spyOn(UserApi, "callUserVerifyApi").mockReturnValue(Future.of(undefined));
 
-            Initialization.generateDevice("jwt", "password").engage(
+            Initialization.generateDevice("jwt", "password", {deviceName: ""}).engage(
                 (e) => {
                     expect(e.code).toEqual(0);
                 },
@@ -193,7 +193,7 @@ describe("Initialization", () => {
                 })
             );
 
-            Initialization.generateDevice("jwt", "password").engage(
+            Initialization.generateDevice("jwt", "password", {deviceName: ""}).engage(
                 (e) => {
                     expect(e.code).toEqual(ErrorCodes.USER_DEVICE_KEY_GENERATION_FAILURE);
                     done();
@@ -220,7 +220,7 @@ describe("Initialization", () => {
                 })
             );
 
-            Initialization.generateDevice("jwt", "password").engage(
+            Initialization.generateDevice("jwt", "password", {deviceName: ""}).engage(
                 (e) => fail(e),
                 (result: any) => {
                     expect(result.accountID).toEqual("353");
@@ -241,7 +241,42 @@ describe("Initialization", () => {
                         {x: expect.any(Buffer), y: expect.any(Buffer)},
                         expect.any(Object),
                         expect.any(Buffer),
-                        expect.any(Number)
+                        expect.any(Number),
+                        {deviceName: ""}
+                    );
+                    done();
+                }
+            );
+        });
+
+        test("should accept user device name in options object", (done) => {
+            jest.spyOn(UserApi, "callUserVerifyApi").mockReturnValue(
+                Future.of({
+                    id: "353",
+                    segmentId: 3,
+                    status: 232,
+                    userMasterPublicKey: TestUtils.accountPublicBytesBase64,
+                    userPrivateKey: Buffer.alloc(96).toString("base64"),
+                })
+            );
+            jest.spyOn(AES, "decryptUserMasterKey").mockReturnValue(Future.of(Buffer.alloc(32)));
+            const deviceAddSpy = jest.spyOn(UserApi, "callUserDeviceAdd");
+            deviceAddSpy.mockReturnValue(
+                Future.of({
+                    devicePublicKey: TestUtils.getEmptyPublicKey(),
+                })
+            );
+
+            Initialization.generateDevice("jwt", "password", {deviceName: "OSX"}).engage(
+                (e) => fail(e),
+                () => {
+                    expect(deviceAddSpy).toHaveBeenCalledWith(
+                        "jwt",
+                        {x: expect.any(Buffer), y: expect.any(Buffer)},
+                        expect.any(Object),
+                        expect.any(Buffer),
+                        expect.any(Number),
+                        {deviceName: "OSX"}
                     );
                     done();
                 }

--- a/tslint.json
+++ b/tslint.json
@@ -30,9 +30,8 @@
         "arrow-return-shorthand": false,
         "no-namespace": [true, "allow-declarations"],
         "no-var-keyword": true,
-        "ban": true,
+        "ban": [true, "fdescribe"],
         "cyclomatic-complexity": [true, 10],
-        "prefer-const": true,
-        "no-var-keyword": true
+        "prefer-const": true
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,10 +18,10 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@ironcorelabs/recrypt-node-binding@0.4.1":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@ironcorelabs/recrypt-node-binding/-/recrypt-node-binding-0.4.1.tgz#805b071a5fed1bbd6cf70721bb5b2efee616f890"
-  integrity sha512-dJOelhO9rRTz44TpdZNJO3eeXn02fnM+EeRz7A9EoD6LBDi9/w+YIV0LmeAsQzAqiTSZc/3/ZzO4kvpX055Jfw==
+"@ironcorelabs/recrypt-node-binding@0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@ironcorelabs/recrypt-node-binding/-/recrypt-node-binding-0.4.2.tgz#2f2cbb0d4c3058d105a9124e1930349859d91cf3"
+  integrity sha512-MR08uyGiJqA8aGyQkVbd9jdhwUMq/+wpLGwVAzF12kB3WchDQvCyFHqILOkkIzhkPD+ltivD02EgAOr2J7i6fw==
   dependencies:
     node-pre-gyp "^0.11.0"
 


### PR DESCRIPTION
This change also reworks some of the document stream encryption workflow so that we first save the encrypted DEK to our service before we start streaming out encrypted bytes.