### PR TITLE
Pin IronCore workflow tags to their dotted names

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   bump:
-    uses: IronCoreLabs/workflows/.github/workflows/bump-version.yaml@bump-version-v1
+    uses: IronCoreLabs/workflows/.github/workflows/bump-version.yaml@bump-version-v1.0.0
     with:
       release_prereleases: false
       version: ${{ inputs.version }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   typescript-release:
-    uses: IronCoreLabs/workflows/.github/workflows/typescript-release.yaml@typescript-release-v1
+    uses: IronCoreLabs/workflows/.github/workflows/typescript-release.yaml@typescript-release-v1.0.0
     with:
       pre_publish_steps: "./build.js"
       publish_working_directory: "dist"

--- a/.github/workflows/typescript-ci.yaml
+++ b/.github/workflows/typescript-ci.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 jobs:
   typescript-ci:
-    uses: IronCoreLabs/workflows/.github/workflows/typescript-ci.yaml@typescript-ci-v0
+    uses: IronCoreLabs/workflows/.github/workflows/typescript-ci.yaml@typescript-ci-v0.0.0
     with:
       test_matrix_node_version: '["20", "22", "24"]'
       # this repo runs coverage in its default test command, which will fail if


### PR DESCRIPTION
`IronCoreLabs/workflows` now publishes its floating tags under dotted names:
`rust-ci-v3.0.0` instead of `rust-ci-v3`. Same commit, same auto-updating
behavior — but Dependabot can parse the dotted form, so this repo will get a PR
when a workflow's next major ships.

The undotted tags are frozen and no longer move, so a repo left on them stops
receiving workflow updates entirely.

See https://github.com/IronCoreLabs/workflows/blob/main/RELEASING.md
